### PR TITLE
Drop unnecessary binding

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ const pDebounce = (fn, wait, options = {}) => {
 			timer = setTimeout(() => {
 				timer = null;
 
-				const result = options.leading ? leadingValue : fn(arguments_);
+				const result = options.leading ? leadingValue : fn(...arguments_);
 
 				for (resolve of resolveList) {
 					resolve(result);

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ const pDebounce = (fn, wait, options = {}) => {
 			timer = setTimeout(() => {
 				timer = null;
 
-				const result = options.leading ? leadingValue : fn.apply(this, arguments_);
+				const result = options.leading ? leadingValue : fn(arguments_);
 
 				for (resolve of resolveList) {
 					resolve(result);

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ const pDebounce = (fn, wait, options = {}) => {
 			}, wait);
 
 			if (runImmediately) {
-				leadingValue = fn.apply(this, arguments_);
+				leadingValue = fn(...arguments_);
 				resolve(leadingValue);
 			} else {
 				resolveList.push(resolve);


### PR DESCRIPTION
`this` here is always `window`/`global`, which means that if the functions actually use `this`, they will refer to `window`/`global`… which is the default.

Am I missing something?

Edit: I suppose this was just to apply the parameters before the spread operator became available.