### PR TITLE
Remove 'use strict'

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const pDebounce = (fn, wait, options = {}) => {
 	if (!Number.isFinite(wait)) {
 		throw new TypeError('Expected `wait` to be a finite number');


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules#other_differences_between_modules_and_standard_scripts

> Also, note that you might get different behavior from sections of script defined inside modules as opposed to in standard scripts. This is because modules use strict mode automatically.

When I see 'use strict' at the top of the code, I suspect it is CommonJS.