### PR TITLE
fix examples

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,9 @@ const expensiveCall = async input => input;
 const debouncedFn = pDebounce(expensiveCall, 200);
 
 for (const number of [1, 2, 3]) {
-	console.log(await debouncedFn(number));
+	debouncedFn(number).then((res)=>{
+		console.log(res);
+	})
 }
 //=> 3
 //=> 3
@@ -76,11 +78,13 @@ const expensiveCall = async value => {
 const debouncedFn = pDebounce.promise(expensiveCall);
 
 for (const number of [1, 2, 3]) {
-	console.log(await debouncedFn(number));
+	debouncedFn(number).then((res)=>{
+	        console.log(res);
+	})
 }
 //=> 1
-//=> 2
-//=> 3
+//=> 1
+//=> 1
 ```
 
 ## Related


### PR DESCRIPTION
the examples are wrong, they both return "1, 2, 3" when instead the first one should return "3, 3, 3" and the second one "1, 1, 1". The error was the use of await in the log function which would prevent pDebounce from doing its work. The fix was to replace with the then() statement to not block pDebounce