### PR TITLE
Fix readme example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -78,9 +78,7 @@ const expensiveCall = async value => {
 const debouncedFn = pDebounce.promise(expensiveCall);
 
 for (const number of [1, 2, 3]) {
-	(async () => {
-		console.log(await debouncedFn(number));
-	})();
+	console.log(await debouncedFn(number));
 }
 //=> 1
 //=> 2


### PR DESCRIPTION
![image](https://github.com/sindresorhus/p-debounce/assets/35442047/83ad4b58-28f6-417c-866b-4fe9ee22ba06)

The example in readme log `1` three times that was not match the comment below, so i fix it to get expected result.